### PR TITLE
Add missing @Configuration Annotations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ With version 2.0 of the api the static api key was removed and users have to req
 
 1. Create two api clients, one with and one without authentication. The authentication interceptor is implemented in step 3. 
 ````kotlin
+@Configuration
 class NordigenClientConfiguration {
 
     @Bean(name = ["NordigenWithAuth"])
@@ -57,6 +58,7 @@ class NordigenClientConfiguration {
 
 2. Create you required clients. The NordigenTokenApi client does not required authentication. All other clients require the authentication
 ````kotlin
+@Configuration
 class NordigenClientConfiguration {
     
     @Bean


### PR DESCRIPTION
In the README there are @Configuration Annotations missing. I have searched hours, why the Beans can't be found and it turns out, the solution was so simple. To prevent others having the same issue, I suggest adding the Annotations to the Readme.

BTW, great Library, keep up the good work 👍 